### PR TITLE
Update for Meteor 0.9+ and add name, git

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,11 +1,13 @@
 Package.describe({
-    summary: "Easy and effective Hotkeys for your app"
+  name: 'flowkey:hotkeys',
+  summary: 'Easy and effective hotkeys for your app, powered by Mousetrap',
+  version: '1.1',
+  git: 'https://github.com/nerdmed/hotkeys.git'
 });
 
-Package.on_use(function(api, where) {
-    api.use(['underscore','check','mousetrap'], "client");
-    api.add_files(['hotkeys.js'], "client");
+Package.onUse(function(api, where) {
+  api.use(['underscore', 'check', 'mousetrap:mousetrap'], 'client');
+  api.addFiles(['hotkeys.js'], 'client');
 
-    api.export("Hotkeys")
-
+  api.export('Hotkeys');
 });


### PR DESCRIPTION
Updating for Meteor 0.9 also requires changing `mrt` to `meteor` in the README etc. That will be left as an exercise to the reader.
